### PR TITLE
修复：审批条件属性比较时取值方式应该为属性，不应该是数据库字段

### DIFF
--- a/ibas.approvalprocess/src/main/java/org/colorcoding/ibas/bobas/approval/initial/ApprovalProcessStepCondition.java
+++ b/ibas.approvalprocess/src/main/java/org/colorcoding/ibas/bobas/approval/initial/ApprovalProcessStepCondition.java
@@ -53,9 +53,9 @@ public class ApprovalProcessStepCondition extends Serializable
 				ArrayList<ApprovalProcessStepCondition> stepConditions = new ArrayList<ApprovalProcessStepCondition>();
 				for (IApprovalTemplateStepCondition item : conditions) {
 					ApprovalProcessStepCondition stepCondition = new ApprovalProcessStepCondition();
-					// 此处需要特别注意：UI编辑时，属性比较用数据库字段；SQL脚本第一个用属性，第二个用数据库字段。
+					// 此处需要特别注意：UI编辑时，属性比较第一个用属性，第二个用输入值；SQL脚本第一个用属性，第二个用数据库字段。
 					if (item.getConditionType() == emApprovalConditionType.PROPERTY_VALUE) {
-						stepCondition.setPropertyValueMode(ValueMode.DB_FIELD);
+						stepCondition.setPropertyValueMode(ValueMode.PROPERTY);
 						stepCondition.setConditionValueMode(ValueMode.INPUT);
 						stepCondition.setRelation(item.getRelationship());
 						stepCondition.setPropertyName(item.getPropertyName());


### PR DESCRIPTION
修复前销售订单审批模板条件为客户编码="M00002",保存报错截图:

![image](https://user-images.githubusercontent.com/16968587/42928902-28fb673e-8b6b-11e8-84c9-f8b2e95bcbd5.png)
